### PR TITLE
Fix launch script

### DIFF
--- a/start.py
+++ b/start.py
@@ -7,13 +7,14 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from revolve.util import Supervisor
 
-os.environ['GAZEBO_PLUGIN_PATH'] = os.path.join(rvpath, 'build')
-os.environ['GAZEBO_MODEL_PATH'] = os.path.join(rvpath, 'worlds')
+if __name__ == "__main__":
+    os.environ['GAZEBO_PLUGIN_PATH'] = os.path.join(rvpath, 'build')
+    os.environ['GAZEBO_MODEL_PATH'] = os.path.join(rvpath, 'worlds')
 
-supervisor = Supervisor(
+    supervisor = Supervisor(
         manager_cmd=None,
         world_file="worlds/gait-learning.world",
         gazebo_cmd="gazebo",
-)
+    )
 
-supervisor.launch_gazebo()
+    supervisor.launch_gazebo()


### PR DESCRIPTION
- read stderr when launching
- non-blocking, immediate stdout and stderr
- if gazebo exits prematurely, raise an exception
(instead of waiting forever)

Windows will not work flawlessly, but still better than before the patch