### PR TITLE
Eval attempt limit

### DIFF
--- a/experiments/examples/manager_pop.py
+++ b/experiments/examples/manager_pop.py
@@ -22,10 +22,10 @@ async def run():
     The main coroutine, which is started below.
     """
     # Parse command line / file input arguments
-    num_generations = 1000
+    num_generations = 100
 
     genotype_conf = PlasticodingConfig(
-        max_structural_modules=100,
+        max_structural_modules=20,
     )
 
     mutation_conf = MutationConfig(
@@ -48,7 +48,7 @@ async def run():
         next_robot_id = 0
 
     population_conf = PopulationConfig(
-        population_size=20,
+        population_size=100,
         genotype_constructor=random_initialization,
         genotype_conf=genotype_conf,
         fitness_function=fitness.displacement_velocity_hill,
@@ -61,7 +61,7 @@ async def run():
         population_management=steady_state_population_management,
         population_management_selector=tournament_selection,
         evaluation_time=settings.evaluation_time,
-        offspring_size=10,
+        offspring_size=100,
         experiment_name=settings.experiment_name,
         experiment_management=experiment_management,
         measure_individuals=settings.measure_individuals,

--- a/pyrevolve/angle/manage/world.py
+++ b/pyrevolve/angle/manage/world.py
@@ -433,12 +433,6 @@ class WorldManager(manage.WorldManager):
 
         future = Future()
         insert_future = await self.insert_model(sdf_bot)
-        # TODO: Unhandled error in exception handler. Fix this.
-        ''' insert_future.add_done_callback(lambda fut: self._robot_inserted(
-            robot=revolve_bot,
-            msg=fut.result(),
-            return_future=future
-        )) '''
         def _callback(_future):
             try:
                 self._robot_inserted(

--- a/pyrevolve/angle/manage/world.py
+++ b/pyrevolve/angle/manage/world.py
@@ -434,11 +434,21 @@ class WorldManager(manage.WorldManager):
         future = Future()
         insert_future = await self.insert_model(sdf_bot)
         # TODO: Unhandled error in exception handler. Fix this.
-        insert_future.add_done_callback(lambda fut: self._robot_inserted(
+        ''' insert_future.add_done_callback(lambda fut: self._robot_inserted(
             robot=revolve_bot,
             msg=fut.result(),
             return_future=future
-        ))
+        )) '''
+        def _callback(_future):
+            try:
+                self._robot_inserted(
+                        robot=revolve_bot,
+                        msg=_future.result(),
+                        return_future=future
+                        )
+            except Exception as e:
+                _future.set_exception(e)
+        insert_future.add_done_callback(_callback)
         return future
 
     def to_sdfbot(

--- a/pyrevolve/evolution/individual.py
+++ b/pyrevolve/evolution/individual.py
@@ -13,6 +13,7 @@ class Individual:
         self.phenotype = phenotype
         self.fitness = None
         self.parents = None
+        self.failed_eval_attempt_count = 0
 
     def develop(self):
         """
@@ -29,3 +30,4 @@ class Individual:
         elif self.genotype.id is not None:
             _id = self.genotype.id
         return f'Individual_{_id}({self.fitness})'
+

--- a/pyrevolve/experiment_management.py
+++ b/pyrevolve/experiment_management.py
@@ -39,14 +39,13 @@ class ExperimentManagement:
         individual.phenotype.render_body('experiments/'+self.settings.experiment_name +'/'+dirpath+'/body_'+str(individual.phenotype.id)+'.png')
         individual.phenotype.render_brain('experiments/'+self.settings.experiment_name +'/'+dirpath+'/brain_' + str(individual.phenotype.id))
 
-
     def export_failed_eval_robot(self,individual):
         if self.settings.recover_enabled:
             individual.genotype.export_genotype('experiments/'+self.settings.experiment_name
-                                                +'/data_fullevolution/failed_eval_robots/genotype_'+str(individual.genotype.id)+'.txt')
+                                                + '/data_fullevolution/failed_eval_robots/genotype_' +str(individual.genotype.id)+'.txt')
         if self.settings.export_phenotype:
             individual.phenotype.save_file('experiments/'+self.settings.experiment_name
-                                           +'/data_fullevolution/failed_eval_robots/phenotype_'+str(individual.genotype.id)+'.yaml')
+                                           + '/data_fullevolution/failed_eval_robots/phenotype_' +str(individual.genotype.id)+'.yaml')
 
     def export_snapshots(self, individuals, gen_num):
         if self.settings.recovery_enabled:

--- a/pyrevolve/experiment_management.py
+++ b/pyrevolve/experiment_management.py
@@ -15,6 +15,8 @@ class ExperimentManagement:
         os.mkdir(dirpath+'/data_fullevolution/genotypes')
         os.mkdir(dirpath+'/data_fullevolution/phenotypes')
         os.mkdir(dirpath+'/data_fullevolution/descriptors')
+        os.mkdir(dirpath+'/data_fullevolution/fitness')
+        os.mkdir(dirpath+'/data_fullevolution/phenotype_images')
         os.mkdir(dirpath+'/data_fullevolution/failed_eval_robots')
 
     def export_genotype(self, individual):
@@ -29,9 +31,14 @@ class ExperimentManagement:
 
     def export_fitnesses(self, individuals):
         for individual in individuals:
-            f = open(f'experiments/{self.settings.experiment_name}/data_fullevolution/fitness_{individual.genotype.id}.txt', "w")
+            f = open(f'experiments/{self.settings.experiment_name}/data_fullevolution/fitness/fitness_{individual.genotype.id}.txt', "w")
             f.write(str(individual.fitness))
             f.close()
+
+    def export_phenotype_images(self, dirpath, individual):
+        individual.phenotype.render_body('experiments/'+self.settings.experiment_name +'/'+dirpath+'/body_'+str(individual.phenotype.id)+'.png')
+        individual.phenotype.render_brain('experiments/'+self.settings.experiment_name +'/'+dirpath+'/brain_' + str(individual.phenotype.id))
+
 
     def export_failed_eval_robot(self,individual):
         if self.settings.recover_enabled:
@@ -48,8 +55,7 @@ class ExperimentManagement:
                 shutil.rmtree('experiments/'+dirpath)
             os.mkdir('experiments/'+dirpath)
             for ind in individuals:
-                ind.phenotype.render_body('experiments/'+dirpath+'/body_'+str(ind.phenotype.id)+'.png')
-                ind.phenotype.render_brain('experiments/'+dirpath+'/brain_' + str(ind.phenotype.id))
+                self.export_phenotype_images('selectedpop_'+str(gen_num), ind)
 
     def experiment_is_new(self):
         if os.path.isfile('experiments/{}/selectedpop_to_recover.txt'.format(self.settings.experiment_name)):

--- a/pyrevolve/experiment_management.py
+++ b/pyrevolve/experiment_management.py
@@ -42,6 +42,8 @@ class ExperimentManagement:
     def export_failed_eval_robot(self,individual):
         individual.genotype.export_genotype(f'experiments/{self.settings.experiment_name}/data_fullevolution/failed_eval_robots/genotype_{str(individual.genotype.id)}.txt')
         individual.phenotype.save_file(f'experiments/{self.settings.experiment_name}/data_fullevolution/failed_eval_robots/phenotype_{str(individual.genotype.id)}.yaml')
+        individual.phenotype.save_file(f'experiments/{self.settings.experiment_name}/data_fullevolution/failed_eval_robots/phenotype_{str(individual.genotype.id)}.sdf', conf_type='sdf')
+
 
     def export_snapshots(self, individuals, gen_num):
         if self.settings.recovery_enabled:

--- a/pyrevolve/experiment_management.py
+++ b/pyrevolve/experiment_management.py
@@ -40,12 +40,8 @@ class ExperimentManagement:
         individual.phenotype.render_brain('experiments/'+self.settings.experiment_name +'/'+dirpath+'/brain_' + str(individual.phenotype.id))
 
     def export_failed_eval_robot(self,individual):
-        if self.settings.recover_enabled:
-            individual.genotype.export_genotype('experiments/'+self.settings.experiment_name
-                                                + '/data_fullevolution/failed_eval_robots/genotype_' +str(individual.genotype.id)+'.txt')
-        if self.settings.export_phenotype:
-            individual.phenotype.save_file('experiments/'+self.settings.experiment_name
-                                           + '/data_fullevolution/failed_eval_robots/phenotype_' +str(individual.genotype.id)+'.yaml')
+        individual.genotype.export_genotype(f'experiments/{self.settings.experiment_name}/data_fullevolution/failed_eval_robots/genotype_{str(individual.genotype.id)}.txt')
+        individual.phenotype.save_file(f'experiments/{self.settings.experiment_name}/data_fullevolution/failed_eval_robots/phenotype_{str(individual.genotype.id)}.yaml')
 
     def export_snapshots(self, individuals, gen_num):
         if self.settings.recovery_enabled:

--- a/pyrevolve/experiment_management.py
+++ b/pyrevolve/experiment_management.py
@@ -15,30 +15,31 @@ class ExperimentManagement:
         os.mkdir(dirpath+'/data_fullevolution/genotypes')
         os.mkdir(dirpath+'/data_fullevolution/phenotypes')
         os.mkdir(dirpath+'/data_fullevolution/descriptors')
-        os.mkdir(dirpath+'/data_fullevolution/fitness')
-        os.mkdir(dirpath+'/data_fullevolution/phenotype_images')
+        os.mkdir(dirpath+'/data_fullevolution/failed_eval_robots')
 
     def export_genotype(self, individual):
-         if self.settings.recovery_enabled:
+        if self.settings.recovery_enabled:
             individual.genotype.export_genotype('experiments/'+self.settings.experiment_name
                                                 +'/data_fullevolution/genotypes/genotype_'+str(individual.genotype.id)+'.txt')
 
     def export_phenotype(self, individual):
         if self.settings.export_phenotype:
             individual.phenotype.save_file('experiments/'+self.settings.experiment_name
-                                            +'/data_fullevolution/phenotypes/phenotype_'+str(individual.genotype.id)+'.yaml')
+                                           +'/data_fullevolution/phenotypes/phenotype_'+str(individual.genotype.id)+'.yaml')
 
     def export_fitnesses(self, individuals):
         for individual in individuals:
-            f = open(f'experiments/{self.settings.experiment_name}/data_fullevolution/fitness/fitness_{individual.genotype.id}.txt', "w")
+            f = open(f'experiments/{self.settings.experiment_name}/data_fullevolution/fitness_{individual.genotype.id}.txt', "w")
             f.write(str(individual.fitness))
             f.close()
 
-    def export_phenotype_images(self, dirpath, individual):
-        individual.phenotype.render_body('experiments/'+self.settings.experiment_name
-                                         +'/'+dirpath+'/body_'+str(individual.phenotype.id)+'.png')
-        individual.phenotype.render_brain('experiments/'+self.settings.experiment_name
-                                          +'/'+dirpath+'/brain_' + str(individual.phenotype.id))
+    def export_failed_eval_robot(self,individual):
+        if self.settings.recover_enabled:
+            individual.genotype.export_genotype('experiments/'+self.settings.experiment_name
+                                                +'/data_fullevolution/failed_eval_robots/genotype_'+str(individual.genotype.id)+'.txt')
+        if self.settings.export_phenotype:
+            individual.phenotype.save_file('experiments/'+self.settings.experiment_name
+                                           +'/data_fullevolution/failed_eval_robots/phenotype_'+str(individual.genotype.id)+'.yaml')
 
     def export_snapshots(self, individuals, gen_num):
         if self.settings.recovery_enabled:
@@ -47,7 +48,8 @@ class ExperimentManagement:
                 shutil.rmtree('experiments/'+dirpath)
             os.mkdir('experiments/'+dirpath)
             for ind in individuals:
-                self.export_phenotype_images('selectedpop_'+str(gen_num), ind)
+                ind.phenotype.render_body('experiments/'+dirpath+'/body_'+str(ind.phenotype.id)+'.png')
+                ind.phenotype.render_brain('experiments/'+dirpath+'/brain_' + str(ind.phenotype.id))
 
     def experiment_is_new(self):
         if os.path.isfile('experiments/{}/selectedpop_to_recover.txt'.format(self.settings.experiment_name)):
@@ -65,5 +67,6 @@ class ExperimentManagement:
             contents = f.read()
         state = contents.split(' ')
         return int(state[0]), int(state[1])
+
 
 

--- a/pyrevolve/util/supervisor/simulator_simple_queue.py
+++ b/pyrevolve/util/supervisor/simulator_simple_queue.py
@@ -94,10 +94,7 @@ class SimulatorSimpleQueue:
                     logger.info("Robot failed to be evaluated 3 times. Fitness set to 0")
                     # Save robot for inspection
                     conf.experiment_management.export_failed_eval_robot(robot)
-                    # Set robot fitness to 0 and remove robot from queue
-                    robot_fitness = 0
-                    future.set_result(robot_fitness)
-                    return True
+                    break
                 return False
             await asyncio.sleep(0.2)
 
@@ -109,7 +106,10 @@ class SimulatorSimpleQueue:
             logger.exception(f"Exception running robot {robot.phenotype}", exc_info=exception)
             return False
 
-        robot_fitness = await evaluation_future
+        if robot.failed_eval_attempt_count == 3:
+            robot_fitness = 0
+        else:
+            robot_fitness = await evaluation_future
         future.set_result(robot_fitness)
 
         return True

--- a/pyrevolve/util/supervisor/simulator_simple_queue.py
+++ b/pyrevolve/util/supervisor/simulator_simple_queue.py
@@ -88,12 +88,6 @@ class SimulatorSimpleQueue:
             # WAITED TO MUCH, RESTART SIMULATOR
             if elapsed > 120:
                 logger.error(f"Simulator restarted after {elapsed}")
-                robot.failed_eval_attempt_count += 1
-                logger.info(f"Robot {robot.phenotype.id} current failed attempt: {robot.failed_eval_attempt_count}")
-                if robot.failed_eval_attempt_count == 3:
-                    logger.info("Robot failed to be evaluated 3 times.")
-                    # Save robot for inspection
-                    conf.experiment_management.export_failed_eval_robot(robot)
                 return False
             await asyncio.sleep(0.2)
 
@@ -119,39 +113,44 @@ class SimulatorSimpleQueue:
             logger.info(f"Picking up robot {robot.phenotype.id} into simulator {i}")
             success = await self._worker_evaluate_robot(self._connections[i], robot, future, conf)
             if success:
+                if robot.failed_eval_attempt_count == 3:
+                    logger.info("Robot failed to be evaluated 3 times. Saving robot to failed_eval file")
+                    conf.experiment_management.export_failed_eval_robot(robot)
                 robot.failed_eval_attempt_count = 0
                 logger.info(f"simulator {i} finished robot {robot.phenotype.id}")
             else:
                 # restart of the simulator happened
+                robot.failed_eval_attempt_count += 1
+                logger.info(f"Robot {robot.phenotype.id} current failed attempt: {robot.failed_eval_attempt_count}")
                 await self._robot_queue.put((robot, future, conf))
                 await self._restart_simulator(i)
             self._robot_queue.task_done()
             self._free_simulator[i] = True
 
     async def _evaluate_robot(self, simulator_connection, robot, conf):
-        await simulator_connection.pause(True)
-        insert_future = await simulator_connection.insert_robot(robot.phenotype, Vector3(0, 0, self._settings.z_start))
-        robot_manager = await insert_future
-        await simulator_connection.pause(False)
-        start = time.time()
-        # Start a run loop to do some stuff
-        max_age = conf.evaluation_time
-        while robot_manager.age() < max_age:
-            await asyncio.sleep(1.0 / 5)  # 5= state_update_frequency
-        end = time.time()
-        elapsed = end-start
-        logger.info(f'Time taken: {elapsed}')
-
         if robot.failed_eval_attempt_count == 3:
             logger.info(f'Robot {robot.phenotype.id} evaluation failed (reached max attempt of 3), fitness set to 0.')
             robot_fitness = 0.00
         else:
+            await simulator_connection.pause(True)
+            insert_future = await simulator_connection.insert_robot(robot.phenotype, Vector3(0, 0, self._settings.z_start))
+            robot_manager = await insert_future
+            await simulator_connection.pause(False)
+            start = time.time()
+            # Start a run loop to do some stuff
+            max_age = conf.evaluation_time
+            while robot_manager.age() < max_age:
+                await asyncio.sleep(1.0 / 5)  # 5= state_update_frequency
+            end = time.time()
+            elapsed = end-start
+            logger.info(f'Time taken: {elapsed}')
+
             robot_fitness = conf.fitness_function(robot_manager)
-        delete_future = await simulator_connection.delete_all_robots()
+            delete_future = await simulator_connection.delete_all_robots()
         # delete_future = await simulator_connection.delete_robot(robot_manager)
-        await delete_future
-        await simulator_connection.pause(True)
-        await simulator_connection.reset(rall=True, time_only=True, model_only=False)
+            await delete_future
+            await simulator_connection.pause(True)
+            await simulator_connection.reset(rall=True, time_only=True, model_only=False)
         return robot_fitness
 
     async def _joint(self):

--- a/render_temp.py
+++ b/render_temp.py
@@ -1,0 +1,13 @@
+from pyrevolve.revolve_bot.revolve_bot import RevolveBot
+import sys
+
+def main():
+    yaml_file_num = sys.argv[1]
+    path = f'/home/amir/projects/revolve/experiments/default_experiment/data_fullevolution/phenotypes/phenotype_{yaml_file_num}.yaml'
+    bot = RevolveBot()
+    bot.load_file(path)
+    bot.render_body(f'/home/amir/projects/revolve/robotimage{yaml_file_num}.png')
+
+if __name__ == '__main__':
+    main()
+

--- a/watch_robots.py
+++ b/watch_robots.py
@@ -7,39 +7,39 @@ from pyrevolve.tol.manage import World
 
 async def run():
 
-	settings = parser.parse_args()
-	yaml_file = 'experiments/'+ settings +'/data_fullevolution/phenotypes/'+'phenotype_'+settings.test_robot+'.yaml'
+    settings = parser.parse_args()
+    yaml_file = f'experiments/{settings.experiment_name}/data_fullevolution/phenotypes/phenotype_{settings.test_robot}.yaml'
 
-	r = RevolveBot(_id=settings.test_robot)
-	r.load_file(yaml_file, conf_type='yaml')
-	#r.save_file('experiments/'+ settings +'/data_fullevolution/phenotype_35.sdf.xml', conf_type='sdf')
-	#r.render_body('experiments/'+ settings +'/data_fullevolution/phenotypes/phenotype_35.body.png')
+    r = RevolveBot(_id=settings.test_robot)
+    r.load_file(yaml_file, conf_type='yaml')
+    # r.save_file('experiments/'+ settings +'/data_fullevolution/phenotype_35.sdf.xml', conf_type='sdf')
+    # r.render_body('experiments/'+ settings +'/data_fullevolution/phenotypes/phenotype_35.body.png')
 
-	connection = await World.create(settings, world_address=("127.0.0.1", settings.port_start))
-	await connection.insert_robot(r)
+    connection = await World.create(settings, world_address=("127.0.0.1", settings.port_start))
+    await connection.insert_robot(r)
 
 
 def main():
-	import traceback
+    import traceback
 
-	def handler(_loop, context):
-		try:
-			exc = context['exception']
-		except KeyError:
-			print(context['message'])
-			return
-		traceback.print_exc()
-		raise exc
+    def handler(_loop, context):
+        try:
+            exc = context['exception']
+        except KeyError:
+            print(context['message'])
+            return
+        traceback.print_exc()
+        raise exc
 
-	try:
-		loop = asyncio.get_event_loop()
-		loop.set_exception_handler(handler)
-		loop.run_until_complete(run())
-	except KeyboardInterrupt:
-		print("Got CtrlC, shutting down.")
+    try:
+        loop = asyncio.get_event_loop()
+        loop.set_exception_handler(handler)
+        loop.run_until_complete(run())
+    except KeyboardInterrupt:
+        print("Got CtrlC, shutting down.")
 
 
 if __name__ == '__main__':
-	print("STARTING")
-	main()
-	print("FINISHED")
+    print("STARTING")
+    main()
+    print("FINISHED")


### PR DESCRIPTION
Counter for keeping track of number of times a robot fails to evaluate (failure = evaluation takes over 120 seconds and simulator has to be restarted). Maximum number of failures for each robot is 3, where the robot is then given a fitness value of 0.

This is to avoid simulation from not being able to finish a generation due to never ending evaluation failures.